### PR TITLE
A working combo!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ install:
     - source activate testenv
     - |
       if [[ "${PYTHON_VERSION}" == "3.6" ]]; then
-        conda install --yes --quiet numpy=1.15.4 matplotlib scipy=1.0 scikit-learn=0.19.1 pandas=0.25.3;
-        pip install mne==0.18.2 PyWavelets=1.0.3 tqdm download;
+        pip install numpy==1.15.4 matplotlib scipy==1.0.1 scikit-learn==0.19.1 pandas==0.25.3;
+        pip install mne==0.18.2 PyWavelets==1.0.3 tqdm download;
       fi;
     - |
       if [[ "${PYTHON_VERSION}" == "3.8" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
       fi;
     - |
       if [[ ( "${USE_NUMBA}" == "ON" ) && ( "${PYTHON_VERSION}" == "3.6" ) ]]; then
-        pip install numba==0.45.0 llvmlite==0.32.1;
+        pip install numba==0.46.0 llvmlite==0.30.0;
       fi;
     - pip install pytest coverage flake8 check-manifest pytest-sugar
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
       fi;
     - |
       if [[ ( "${USE_NUMBA}" == "ON" ) && ( "${PYTHON_VERSION}" == "3.6" ) ]]; then
-        pip install numba==0.45.0
+        pip install numba==0.45.0 llvmlite==0.32.1;
       fi;
     - pip install pytest coverage flake8 check-manifest pytest-sugar
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
     - source activate testenv
     - |
       if [[ "${PYTHON_VERSION}" == "3.6" ]]; then
-        pip install numpy==1.15.4 matplotlib scipy==1.0 scikit-learn==0.20.4 pandas==0.25.3;
+        pip install numpy==1.17.0 matplotlib scipy==1.3.0 scikit-learn==0.20.4 pandas==0.25.0;
         pip install mne==0.18.2 PyWavelets==1.0.3 tqdm download;
       fi;
     - |
@@ -25,7 +25,7 @@ install:
       fi;
     - |
       if [[ ( "${USE_NUMBA}" == "ON" ) && ( "${PYTHON_VERSION}" == "3.6" ) ]]; then
-        pip install numba==0.45.1
+        pip install numba==0.45.0
       fi;
     - pip install pytest coverage flake8 check-manifest pytest-sugar
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
     - source activate testenv
     - |
       if [[ "${PYTHON_VERSION}" == "3.6" ]]; then
-        pip install numpy==1.17.0 matplotlib scipy==1.3.0 scikit-learn==0.20.4 pandas==0.25.0;
+        pip install numpy==1.17.0 matplotlib scipy==1.3.0 scikit-learn==0.21.0 pandas==0.25.0;
         pip install mne==0.18.2 PyWavelets==1.0.3 tqdm download;
       fi;
     - |

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ clean: clean-build clean-pyc clean-so clean-ctags
 
 in: inplace # just a shortcut
 inplace:
-	$(PYTHON) setup.py develop
+	$(PYTHON) setup.py develop --no-deps
 
 test: inplace test-manifest
 	rm -f .coverage

--- a/mne_features/mock_numba.py
+++ b/mne_features/mock_numba.py
@@ -4,12 +4,10 @@
 #         Alexandre Gramfort <alexandre.gramfort@inria.fr>
 # License: BSD 3 clause
 
-from warnings import warn
-
 try:
     import numba as nb
-except (ImportError, ModuleNotFoundError) as e:
-    warn('{}. Your code will be slower.'.format(e))
+except ImportError as err:
+    print('{}. Your code will be slower.'.format(err))
 
     class Bunch(dict):
         """Dictionnary-like object that exposes its keys as attributes."""

--- a/mne_features/mock_numba.py
+++ b/mne_features/mock_numba.py
@@ -8,7 +8,7 @@ from warnings import warn
 
 try:
     import numba as nb
-except ImportError as e:
+except (ImportError, ModuleNotFoundError) as e:
     warn('{}. Your code will be slower.'.format(e))
 
     class Bunch(dict):


### PR DESCRIPTION
I got it to work. Here is what I did:

- set the minimal versions of numpy and scipy to releases which are compatible with python>=3.5
- some versions of numba and llvmlite are incompatible ; the pairing numba==0.46.0 + llvmlite==0.30.0 works but numba==0.45.1 alone does not work (at least it did not work for me...)
- added `--no-deps` to `python setup.py develop` in Makefile (otherwise it may install numba)
- in `mock_numba.py`, the line `warn('{}. Your code will be slower.'.format(e))` would not catch the `ImportError` when pytest is run. Replacing it with a simple `print(...)` actually catches the error and allows pytest to carry on

Is this minimal setup OK with you?